### PR TITLE
Add proliferation todo list file

### DIFF
--- a/project_ratio_proliferation.txt
+++ b/project_ratio_proliferation.txt
@@ -1,0 +1,9 @@
+# Project Ratio Proliferation
+
+[ ] Add proliferation status to Product
+[ ] Tag Recipes by proliferation ability
+[ ] Generate Spray Coater Recipes
+[ ] Generate all proliferated Recipes
+[ ] Add proliferation questions to UI
+[ ] Recipe Crafters might need proliferation info
+[ ] Spray Coater recipes will need belt speeds


### PR DESCRIPTION
Closes #3. It turns out the `project_ratio_copy/` directory had no code changes and could just be deleted, so there was only one other text file to add.